### PR TITLE
performance-verifier: display the location of the overrides file

### DIFF
--- a/performance-verifier/src/main/java/uk/gov/justice/performance/PerformanceVerifierBase.java
+++ b/performance-verifier/src/main/java/uk/gov/justice/performance/PerformanceVerifierBase.java
@@ -6,6 +6,8 @@ import static uk.gov.justice.performance.utils.CommonConstant.OVERRIDES_FILE_PRO
 import java.util.Properties;
 
 import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import uk.gov.justice.performance.artemis.ArtemisJmxService;
 import uk.gov.justice.performance.artemis.DefaultArtemisJmxService;
@@ -20,7 +22,9 @@ public class PerformanceVerifierBase {
 
     @BeforeClass
     public static void setup() {
+        Logger logger = LoggerFactory.getLogger(PerformanceVerifierBase.class);
         props = PropertiesFactory.safeLoadDefaultsAndOverrides('/' + DEFAULT_PROPERTIES_FILE, System.getProperty(OVERRIDES_FILE_PROPERTY_NAME,""));
+        logger.info("Overrides file: {}", System.getProperty(OVERRIDES_FILE_PROPERTY_NAME));
         artemisJmxService = new DefaultArtemisJmxService(props);
         wildflyJmxService = new DefaultWildflyJmxService(props);
     }


### PR DESCRIPTION
Simplifies debugging, given that system properties need to be supplied
before the -jar option on a command line invocation